### PR TITLE
Add raycast-g4f extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [Serverless Telegram bot](https://github.com/franalgaba/chatgpt-telegram-bot-serverless) ChatGPT Telegram Bot running in AWS Lambda
 - [WhatsApp bot](https://github.com/danielgross/whatsapp-gpt) gpt for whatsapp
 - [RayCast Extension (unofficial)](https://github.com/abielzulio/chatgpt-raycast) ChatGPT raycast extension
+- [raycast-g4f Extension (unofficial)](https://github.com/XInTheDark/raycast-g4f) Use many GPT models completely for free, on Raycast. NO API Key required!
 - [Go Telegram bot](https://github.com/m1guelpf/chatgpt-telegram) Run your own GPTChat Telegram bot, with a single command!
 - [Twitter Bot](https://github.com/transitive-bullshit/chatgpt-twitter-bot) Twitter bot powered by OpenAI's ChatGPT API. It's aliveeeee 🤖
 - [myGPTReader](https://github.com/madawei2699/myGPTReader) - Slack bot that can read any webpage, YouTube video, or document and summarize it. Voice output. Chinese support.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -166,6 +166,7 @@
 - [Serverless Telegram bot](https://github.com/franalgaba/chatgpt-telegram-bot-serverless) ChatGPT Telegram Bot running in AWS Lambda
 - [WhatsApp bot](https://github.com/danielgross/whatsapp-gpt) gpt for whatsapp
 - [RayCast Extension (unofficial)](https://github.com/abielzulio/chatgpt-raycast) ChatGPT raycast extension
+- [raycast-g4f Extension (unofficial)](https://github.com/XInTheDark/raycast-g4f) Use many GPT models completely for free, on Raycast. NO API Key required!
 - [Go Telegram bot](https://github.com/m1guelpf/chatgpt-telegram) Run your own GPTChat Telegram bot, with a single command!
 - [Twitter Bot](https://github.com/transitive-bullshit/chatgpt-twitter-bot) Twitter bot powered by OpenAI's ChatGPT API. It's aliveeeee 🤖
 - [myGPTReader](https://github.com/madawei2699/myGPTReader) - Slack bot that can read any webpage, YouTube video, or document and summarize it. Voice output. Chinese support.


### PR DESCRIPTION
Hi,

This adds raycast-g4f extension, an unofficial GPT raycast extension I made myself. It's similar to the concept of the gpt4free project, providing decentralized chatbot access completely for free to users. This means it can operate without an API Key, instead utilizing GPT output from various free APIs.

GitHub: https://github.com/XInTheDark/raycast-g4f/
Sample screenshots: https://github.com/XInTheDark/raycast-g4f/tree/main/metadata