### PR TITLE
Add GPT Mobile Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [Smalltalk](https://github.com/tinystruct/smalltalk) A funny anonymous chat software which integrated with OpenAI ChatGPT and Stability AI. 
 - [Delphi Chat GPT](https://github.com/HemulGM/ChatGPT) Delphi Chat GPT with FMX
 - [Horizon AI Template](https://github.com/horizon-ui/chatgpt-ai-template) Trendiest Open-Source ChatGPT AI Template & Starter Kit for React & NextJS
+- [GPT Mobile](https://github.com/Taewan-P/gpt_mobile) GPT Mobile is an Android app that can chat with multiple LLMs at once! Currently supports ChatGPT, Anthropic Claude, and Google Gemini.
 
 ## CLI tools
 


### PR DESCRIPTION
Hi,

GPT Mobile is an Android app that can chat with multiple LLMs at once! It currently supports ChatGPT, Anthropic Claude, and Google Gemini. When starting a chat, you can choose which platforms to get answers from. Also, the chat history is only saved locally and only sends to official API servers while chatting.

Currently planning to support multi-modal features in chat! 

GitHub: https://github.com/Taewan-P/gpt_mobile


