### PR TITLE
Improve ChatGPT Auto-Continue descriptions, added missing star count + to Browser Extensions + to Chinese docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
 - [Meeper](https://github.com/pas1ko/meeper) - Transcriptions, summary and more using ChatGPT and Whisper for meetings and any browser tab
 - [XReplyGPT](https://github.com/marcolivierbouch/XReplyGPT) - Is a free Chrome extension that allows you to generates reply automatically for https://x.com/https://twitter.com.
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating answers when ChatGPT responses get cut-off
 
 ## Desktop Applications
 
@@ -333,5 +334,5 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [ChatGPT Widescreen Mode](https://chatgptwidescreen.com) 🖥️ Add Widescreen + Fullscreen modes to ChatGPT for enhanced viewing
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
 - [ChatGPT Export](https://github.com/yaph/chatgpt-export) A browser bookmarklet for exporting conversations with ChatGPT as markdown files.
-- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating multiple ChatGPT responses.
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating answers when ChatGPT responses get cut-off
 - [AmazonGPT](https://github.com/KudoAI/amazongpt/) 🛒 Adds AI assistance to Amazon shopping

--- a/README.star.md
+++ b/README.star.md
@@ -134,6 +134,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
 - [Meeper](https://github.com/pas1ko/meeper) 59⭐️ - Transcriptions, summary and more using ChatGPT and Whisper for meetings and any browser tab
 - [XReplyGPT](https://github.com/marcolivierbouch/XReplyGPT) 42⭐️ - Is a free Chrome extension that allows you to generates reply automatically for https://x.com/https://twitter.com.
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) 156⭐️ ⏩ Automatically continue generating multiple ChatGPT responses.
 
 ## Desktop Applications
 
@@ -333,5 +334,5 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [ChatGPT Widescreen Mode](https://chatgptwidescreen.com) 🖥️ Add Widescreen + Fullscreen modes to ChatGPT for enhanced viewing
 - [ChatGPT Infinity](https://chatgptinfinity.com) ∞ Generate endless answers from all-knowing ChatGPT (in any language!)
 - [ChatGPT Export](https://github.com/yaph/chatgpt-export) 62⭐️ A browser bookmarklet for exporting conversations with ChatGPT as markdown files.
-- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating multiple ChatGPT responses.
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) 156⭐️ ⏩ Automatically continue generating multiple ChatGPT responses.
 - [AmazonGPT](https://github.com/KudoAI/amazongpt/) 30⭐️ 🛒 Adds AI assistance to Amazon shopping

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -131,6 +131,7 @@
 - [ChatGPT-Prompt-Genius](https://github.com/benf2004/ChatGPT-Prompt-Genius) Multi-purpose ChatGPT Chrome Extension
 - [ReadAnything](https://github.com/Zhangyanbo/ReadAnything) Read any hard content with the help of GPT
 - [ChatGPT Widescreen Mode](https://chatgptevo.com/widescreen) 🖥️ Add Widescreen + Full-Window modes to ChatGPT for enhanced viewing
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 
 ## 桌面应用
 
@@ -276,4 +277,5 @@
 - [Autoclear ChatGPT History](https://autoclearchatgpt.com) 🕶️ Adds chat auto-clear functionality to ChatGPT for more privacy
 - [DuckDuckGPT](https://duckduckgpt.com) 🐤 Adds the magic of ChatGPT to DuckDuckGo sidebar
 - [BraveGPT](https://bravegpt.com) 🦁 Adds the magic of ChatGPT to Brave Search sidebar
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 - [AmazonGPT](https://github.com/KudoAI/amazongpt/) 🛒 为 Amazon 购物添加人工智能辅助

--- a/README.zh-cn.star.md
+++ b/README.zh-cn.star.md
@@ -131,6 +131,7 @@
 - [ChatGPT-Prompt-Genius](https://github.com/benf2004/ChatGPT-Prompt-Genius) 1120⭐️ Multi-purpose ChatGPT Chrome Extension
 - [ReadAnything](https://github.com/Zhangyanbo/ReadAnything) 28⭐️ Read any hard content with the help of GPT
 - [ChatGPT Widescreen Mode](https://chatgptevo.com/widescreen) 🖥️ Add Widescreen + Full-Window modes to ChatGPT for enhanced viewing
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) 156⭐️ ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 
 ## 桌面应用
 
@@ -276,4 +277,5 @@
 - [Autoclear ChatGPT History](https://autoclearchatgpt.com) 🕶️ Adds chat auto-clear functionality to ChatGPT for more privacy
 - [DuckDuckGPT](https://duckduckgpt.com) 🐤 Adds the magic of ChatGPT to DuckDuckGo sidebar
 - [BraveGPT](https://bravegpt.com) 🦁 Adds the magic of ChatGPT to Brave Search sidebar
+- [ChatGPT Auto-Continue](https://chatgptautocontinue.com) 156⭐️ ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 - [AmazonGPT](https://github.com/KudoAI/amazongpt/) 30⭐️ 🛒 为 Amazon 购物添加人工智能辅助


### PR DESCRIPTION
For ChatGPT Auto-Continue

- Changed "Automatically continue generating multiple ChatGPT responses" to more clear "Automatically continue generating answers when ChatGPT responses get cut-off"
- Added missing star count in README.star.md
- Duplicated from User scripts to Browser extensions since it has since been ported to Chrome/Edge/FF web stores
- Translated/added to README.zh-cn.md + README.zh-cn.star.md