### PR TITLE
Add Not Human Search and AI Dev Board to API tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [Embedchain](https://github.com/embedchain/embedchain): Framework to create ChatGPT like bots over your dataset.
 - [one-api](https://github.com/songquanpeng/one-api): OpenAI key management & redistribution system, using a single API for all LLMs, and features an English UI.
 - [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api): Multi-provider LLM gateway — route requests to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through a unified OpenAI-compatible API. BYO keys, response caching, automatic retries. 24+ models.
+- [Not Human Search](https://nothumansearch.ai): MCP-first search engine that indexes agent-ready sites (llms.txt, OpenAPI, MCP). REST API + MCP server with `search` and `verify_mcp` tools. OpenAPI at /openapi.yaml.
+- [AI Dev Board](https://aidevboard.com): AI/ML jobs board with a public REST API (8k+ listings, Go/Postgres, full-text search via tsquery) and MCP server. OpenAPI at /openapi.yaml.
 
 ## Client-side tools
 


### PR DESCRIPTION
Two agent-ready REST APIs + MCP servers that fit the API tools section:

- **[Not Human Search](https://nothumansearch.ai)** — MCP-first search engine indexing sites with llms.txt, OpenAPI, and MCP endpoints. Exposes a REST API and MCP server (`search`, `verify_mcp` tools). OpenAPI spec at /openapi.yaml.
- **[AI Dev Board](https://aidevboard.com)** — AI/ML jobs board with a public REST API (8k+ listings, Go/Postgres, full-text search via tsquery) and MCP server. OpenAPI spec at /openapi.yaml.

Both are live production services with documented APIs useful for GPT/agent integrations.