### PR TITLE
Add AI Model Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [DelphiOpenAI](https://github.com/HemulGM/DelphiOpenAI) OpenAI API client for Delphi. Use ChatGPT, DALL-E and other products
 - [Embedchain](https://github.com/embedchain/embedchain): Framework to create ChatGPT like bots over your dataset.
 - [one-api](https://github.com/songquanpeng/one-api): OpenAI key management & redistribution system, using a single API for all LLMs, and features an English UI.
+- [AI Model Gateway](https://github.com/SSC-STUDIO/Ai-Model-Gateway): Self-hosted LLM operations gateway for OpenAI-compatible and Anthropic-compatible routing, fallback, telemetry, benchmarking, config publishing, updates, and rollback.
 - [Agent LLM Router](https://api-catalog-three.vercel.app/blog/free-llm-api): Multi-provider LLM gateway — route requests to OpenAI, Anthropic, Google Gemini, Groq, Together AI, DeepSeek through a unified OpenAI-compatible API. BYO keys, response caching, automatic retries. 24+ models.
 - [Not Human Search](https://nothumansearch.ai): MCP-first search engine indexing 1,700+ agent-ready sites — live JSON-RPC verification, public REST API, and MCP server. Free tier; `claude mcp add nothumansearch`.
 - [AI Dev Jobs](https://aidevboard.com): REST API and MCP server for 8,400+ AI/ML job listings at 489 companies. OpenAPI 3.0 spec, free tier (100 req/hr), programmatic access for agent-driven recruiting pipelines.


### PR DESCRIPTION
Adds [AI Model Gateway](https://github.com/SSC-STUDIO/Ai-Model-Gateway) to the API tools section.

Why it fits:
- It is an open-source, self-hosted LLM operations gateway.
- It exposes OpenAI-compatible and Anthropic-compatible provider routing with fallback, telemetry, benchmarking, config publishing, update, and rollback workflows.
- This section already includes adjacent unified API/gateway tools such as `one-api` and Agent LLM Router.

Disclosure: I maintain AI Model Gateway, so this is a self-submission. I kept the entry to one factual README line.