### PR TITLE
feat: add NotFair — Claude Code skills for SEO, Google Ads, and Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [CLI-Co-Pilot](https://github.com/AntonOsika/CLI-Co-Pilot) CLI tool that uses Codex to turn natural language commands into their Bash/ZShell/PowerShell equivalents
 - [cli-gpt](https://github.com/MagicCube/cli-gpt) Translate human language to command line using ChatGPT
 - [Toprank](https://github.com/nowork-studio/toprank) Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to ship fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.
+- [NotFair](https://github.com/nowork-studio/NotFair) Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword research, meta tag optimisation, schema markup, and paid-ads management from the CLI.
 - [HappyCommit](https://github.com/jackbackes/happycommit) HappyCommit is a delightful tool that harnesses the power of OpenAI's GPT-3.5 Turbo language model to generate meaningful and descriptive Git commit messages for you
 - [ai-commit](https://github.com/guanguans/ai-commit) Automagically generate conventional git commit messages with AI.
 - [autodoc](https://github.com/context-labs/autodoc) Autodoc is a experimental toolkit for auto-generating codebase documentation for git repositories using Large Language Models, like GPT-4 or Alpaca. 


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source (MIT) Claude Code plugin that adds agent skills for SEO, GEO, Google Ads, and Meta Ads — similar in spirit to Toprank (already in the CLI tools section), but broader in scope and actively maintained as a separate project.

It has around ~2.9k stars and connects to live account data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. The skills cover site audits, keyword research, meta tag optimisation, schema markup, GEO optimisation, wasted-spend detection, and Meta Ads ROAS/creative analysis — all runnable from the CLI via Claude Code.

I've placed it right after the existing Toprank entry in the CLI tools section, matching the same format. Happy to reword, move, or trim if preferred.