### PR TITLE
docs: add GPT for Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 ### Other
 
 - [Google docs](https://github.com/cesarhuret/docGPT)  ChatGPT directly within Google Docs as an Editor Add-on.
+- [GPT for Sheets](https://docgpt.ai/gpt-for-sheets) Use ChatGPT, Claude, Gemini, OpenRouter and 100+ AI models inside Google Sheets for formulas, enrichment, and bulk workflows.
 - [add-chatgpt-to-microsoft-word](https://github.com/analyticsinmotion/add-chatgpt-to-microsoft-word) How to add ChatGPT's Text Completion to Microsoft Word
 - [Composum AI](https://github.com/ist-dresden/composum-AI) OpenAI based GenAI extension for the CMS Adobe Experience Manager (AEM) or the free Composum Pages CMS to analyze, discuss, suggest, translate, transform texts, incl. free prompting
 


### PR DESCRIPTION
## Summary
- Add GPT for Sheets to the ChatGPT integrated projects list
- Keep the description concise and factual

GPT for Sheets brings ChatGPT and other AI models into Google Sheets for formulas, enrichment, and bulk spreadsheet workflows.