### PR TITLE
Add SandBase CLI to API tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 
 ## API tools
 
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source command-line tool and MCP bridge for accessing 2,000+ AI models through one interface.
+
 - [toolkit-ai](https://github.com/hey-pal/toolkit-ai) AI-agents that automatically generate and use Langchain Tools and ChatGPT plugins
 - [whetstone.chatgpt](https://github.com/johniwasz/whetstone.chatgpt) A simple light-weight library that wraps the GPT-3 API with support for dependency injection
 - [chatgpt-starter](https://github.com/zhangjh/chatgpt-starter) A chatgpt starter based on springboot to provider chatgpt api for java
@@ -267,4 +269,3 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 
 - [GPTGeminiGrok.AI](https://trygrokai.asia/) - Browser-based workspace for GPT, Gemini, and Grok chat, image generation, and everyday productivity workflows.
 - [Eimu](https://eimu.art) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
-

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -86,6 +86,7 @@
 
 
 ## API 工具
+- [SandBase CLI](https://github.com/sandbaseai/cli) - 开源命令行工具和 MCP 桥接器，通过统一接口访问 2,000+ AI 模型。
 - [toolkit-ai](https://github.com/hey-pal/toolkit-ai) 自动生成和使用 Langchain Tools 和 ChatGPT 插件的 AI-agents
 - [whetstone.chatgpt](https://github.com/johniwasz/whetstone.chatgpt) 一个简单的轻量级库，包装GPT-3 API，支持依赖性注入
 - [chatgpt-starter](https://github.com/zhangjh/chatgpt-starter) 基于 spring boot 的 chatGPT 启动器，为 java 提供 chatGPT api


### PR DESCRIPTION
## Summary
- add SandBase CLI to the API tools section in English and Simplified Chinese
- link to the canonical open-source repository and describe its MCP bridge for 2,000+ AI models

The entry follows the repository's existing concise list style and adds a developer-focused, open-source GPT resource.
