### PR TITLE
Add BrandQuill Word document extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [XReplyGPT](https://github.com/marcolivierbouch/XReplyGPT) - Is a free Chrome extension that allows you to generates reply automatically for https://x.com/https://twitter.com.
 - [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating answers when ChatGPT responses get cut-off
 - [DockyAI](https://docky.ai/) ⏩ Docky AI is a powerful browser extension that allows you to have real-time conversations with multiple AI models through a sidebar. It supports simultaneous communication with multiple models and can assist you in reading web pages, writing, translating, and creating images
+- [BrandQuill](https://brandquill.app/extension?utm_source=awesome_gpt&utm_medium=repository&utm_campaign=chatgpt_to_word_extension) - Turn ChatGPT, Claude, Gemini, Copilot, Notion, and Markdown output into editable Word documents using your own DOCX template. Browser-local processing, with a Microsoft Edge add-on.
 - [ChatGPT Toolbox](https://chromewebstore.google.com/detail/chatgpt-toolbox/jlalnhjkfiogoeonamcnngdndjbneina) - All-in-one ChatGPT power user extension — full-text search history, folders, 300+ prompt library with chaining, bookmarks, DALL-E gallery, MP3 voice download, usage tracker, bulk export/delete/archive, and 40+ more features in 10 languages.
 
 ## Desktop Applications

--- a/README.star.md
+++ b/README.star.md
@@ -145,6 +145,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [XReplyGPT](https://github.com/marcolivierbouch/XReplyGPT) 63⭐️ - Is a free Chrome extension that allows you to generates reply automatically for https://x.com/https://twitter.com.
 - [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ Automatically continue generating answers when ChatGPT responses get cut-off
 - [DockyAI](https://docky.ai/) ⏩ Docky AI is a powerful browser extension that allows you to have real-time conversations with multiple AI models through a sidebar. It supports simultaneous communication with multiple models and can assist you in reading web pages, writing, translating, and creating images
+- [BrandQuill](https://brandquill.app/extension?utm_source=awesome_gpt&utm_medium=repository&utm_campaign=chatgpt_to_word_extension) - Turn ChatGPT, Claude, Gemini, Copilot, Notion, and Markdown output into editable Word documents using your own DOCX template. Browser-local processing, with a Microsoft Edge add-on.
 - [ChatGPT Toolbox](https://chromewebstore.google.com/detail/chatgpt-toolbox/jlalnhjkfiogoeonamcnngdndjbneina) - All-in-one ChatGPT power user extension — full-text search history, folders, 300+ prompt library with chaining, bookmarks, DALL-E gallery, MP3 voice download, usage tracker, bulk export/delete/archive, and 40+ more features in 10 languages.
 
 ## Desktop Applications

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -134,6 +134,7 @@
 - [ChatGPT Widescreen Mode](https://chatgptevo.com/widescreen) 🖥️ Add Widescreen + Full-Window modes to ChatGPT for enhanced viewing
 - [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 - [DockyAI](https://docky.ai/) ⏩ Docky AI 是一款功能强大的浏览器插件，允许您通过侧边栏与多个 AI 模型进行实时对话。它支持多模型同时交流，并能协助您阅读网页、写作、翻译和创作图片
+- [BrandQuill](https://brandquill.app/extension?utm_source=awesome_gpt&utm_medium=repository&utm_campaign=chatgpt_to_word_extension) - 使用自己的 DOCX 模板，将 ChatGPT、Claude、Gemini、Copilot、Notion 和 Markdown 输出转换为可编辑的 Word 文档。浏览器本地处理，并提供 Microsoft Edge 扩展。
 - [ChatGPT Toolbox](https://chromewebstore.google.com/detail/chatgpt-toolbox/jlalnhjkfiogoeonamcnngdndjbneina) - ChatGPT 全能增强扩展 — 全文搜索聊天记录、文件夹管理、300+ 提示词库与提示词链、书签、DALL-E 图库、MP3 语音下载、用量追踪、批量导出/删除/归档，40+ 功能，支持10种语言。
 
 ## 桌面应用

--- a/README.zh-cn.star.md
+++ b/README.zh-cn.star.md
@@ -134,6 +134,7 @@
 - [ChatGPT Widescreen Mode](https://chatgptevo.com/widescreen) 🖥️ Add Widescreen + Full-Window modes to ChatGPT for enhanced viewing
 - [ChatGPT Auto-Continue](https://chatgptautocontinue.com) ⏩ 当 ChatGPT 响应中断时自动继续生成答案
 - [DockyAI](https://docky.ai/) ⏩ Docky AI 是一款功能强大的浏览器插件，允许您通过侧边栏与多个 AI 模型进行实时对话。它支持多模型同时交流，并能协助您阅读网页、写作、翻译和创作图片
+- [BrandQuill](https://brandquill.app/extension?utm_source=awesome_gpt&utm_medium=repository&utm_campaign=chatgpt_to_word_extension) - 使用自己的 DOCX 模板，将 ChatGPT、Claude、Gemini、Copilot、Notion 和 Markdown 输出转换为可编辑的 Word 文档。浏览器本地处理，并提供 Microsoft Edge 扩展。
 - [ChatGPT Toolbox](https://chromewebstore.google.com/detail/chatgpt-toolbox/jlalnhjkfiogoeonamcnngdndjbneina) - ChatGPT 全能增强扩展 — 全文搜索聊天记录、文件夹管理、300+ 提示词库与提示词链、书签、DALL-E 图库、MP3 语音下载、用量追踪、批量导出/删除/归档，40+ 功能，支持10种语言。
 
 ## 桌面应用


### PR DESCRIPTION
Adds BrandQuill to the Browser Extensions section in the English and Chinese lists.

BrandQuill turns ChatGPT and other AI output into editable Word documents using a user's own DOCX template. Processing stays in the browser, and the public Microsoft Edge add-on is linked from the product page.

I am the owner of BrandQuill. Both the product page and Microsoft Edge listing return successfully. This submission follows the same four-file pattern as the recently accepted ChatGPT Toolbox extension contribution.