### PR TITLE
Add YYLO to CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [Eimu](https://eimu.art) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - [Agent QA](https://github.com/vostride/agent-qa) - Source-available QA agent for natural-language web and mobile tests using OpenAI-compatible models, with persistent test memory, a dashboard, CLI, and MCP server.
 
+## CLI tools
+
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries. Each task gets a dedicated branch/worktree, the merge queue owns risk-based review, and subagents such as Pi and Codex do the work.
+
 ## Prompts
 
 - [AILesson Prompts](https://ailesson.io/prompts) - 300+ practical prompt recipes for work, learning, research, planning, and everyday tasks.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -244,6 +244,7 @@
 - [ai-commit](https://github.com/guanguans/ai-commit) Automagically generate conventional git commit messages with AI.
 - [autodoc](https://github.com/context-labs/autodoc) Autodoc is a experimental toolkit for auto-generating codebase documentation for git repositories using Large Language Models, like GPT-4 or Alpaca.
 - [prompt](https://github.com/raiyanyahya/prompt) 🥝 一个与 OpenAI ChatGPT API 互动的命令行程序。
+- [YYLO](https://github.com/yylo-dev/yylo) 面向编码智能体的命令行编排器，提供带类型的任务、验证、合并与发布就绪边界；每个任务使用专属分支/worktree，合并队列负责基于风险的审查，由 Pi 和 Codex 等子智能体执行工作。
 
 
 


### PR DESCRIPTION
## Summary

Adds **YYLO** — a command-line orchestrator for coding agents — and restores the `## CLI tools` section header in the English README (one entry: YYLO).

## Why the section restore

PR #200 (2026-07-29, "Add GPTGemniGrok.AI web application") unintentionally removed the trailing `## Applications` / `## CLI tools` / `## Github Actions` / `## Cybersecurity` sections from `README.md` (−92 lines), even though its description stated "No existing entries removed or changed". Evidence this was accidental rather than intentional pruning:

- The **Table of Contents still links `CLI tools`** (and the other removed sections) — the ToC was never updated.
- `README.zh-cn.md` **still contains the intact 命令行工具 (CLI tools) section** (Tura, CLI-Co-Pilot, aicommits, …).

This PR restores just the `## CLI tools` header between `Web applications` and `Prompts` (matching the ToC order) and adds YYLO as its first entry, plus the matching Chinese line in the existing `命令行工具` section of `README.zh-cn.md`. If you'd rather keep the section removed, I'm happy to re-file with YYLO appended to another section of your choice.

## What this adds

- **YYLO** (`github.com/yylo-dev/yylo`) — command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries. Each task gets a dedicated branch/worktree, the merge queue owns risk-based review, and subagents such as **Pi and Codex** do the work. MIT, npm `@yylo/cli`, 57★, daily commits.

Sits beside the CLI-agent tool family (CLI-Co-Pilot "uses Codex", Tura coding agent, aicommits, cz-git) already in the Chinese CLI-tools section.

## Disclosure

I'm on the team that builds YYLO; this PR was prepared with an AI coding agent and reviewed by me. Happy to adjust the wording or drop the section restore if you prefer.

## Verification

- Entry phrases are taken verbatim from the YYLO README ("command-line orchestrator for coding agents", "typed task, validation, merge, and release-readiness boundaries", "creates a dedicated branch/worktree", "the merge queue owns risk-based review", "Pi and Codex").
- `git diff --check` clean; no ToC or generated files touched; star-variant READMEs are untouched (refreshed by your daily workflow).
