### PR TITLE
Add StudyArena to Web applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ If you created or found any awesome resource about ChatGPT, Your contributions a
 - [GPTGeminiGrok.AI](https://trygrokai.asia/) - Browser-based workspace for GPT, Gemini, and Grok chat, image generation, and everyday productivity workflows.
 - [Eimu](https://eimu.art) - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - [Agent QA](https://github.com/vostride/agent-qa) - Source-available QA agent for natural-language web and mobile tests using OpenAI-compatible models, with persistent test memory, a dashboard, CLI, and MCP server.
+- [StudyArena](https://studyarena.com) - Free three-model answer comparisons for study questions, with a blind vote followed by model reveal.
 
 ## CLI tools
 


### PR DESCRIPTION
I've been building StudyArena around a simple study workflow: ask one question, compare three answers without the model names, then vote and reveal them. The comparison flow is free.

This adds it to Web applications, alongside the existing multi-model chat and learning apps. I used the canonical homepage, kept the change to one entry in README.md, and checked the project name and both domains across repository files and open and closed issues and PRs. The link returns HTTP 200 and `git diff --check` passes.
